### PR TITLE
fix: read $KUBECONFIG from env if it exists

### DIFF
--- a/util.go
+++ b/util.go
@@ -79,7 +79,9 @@ func buildPvcbGetJob(namespace string, image string, pvc corev1.PersistentVolume
 func getClientSetFromKubeconfig() (*kubernetes.Clientset, *rest.Config) {
 	var kubeconfig string
 
-	if home := homedir.HomeDir(); home != "" {
+	if configFromEnv := os.Getenv("KUBECONFIG"); configFromEnv != "" {
+		kubeconfig = configFromEnv
+	} else if home := homedir.HomeDir(); home != "" {
 		kubeconfig = filepath.Join(home, ".kube", "config")
 	} else {
 		fmt.Println("error: unable to locate kubeconfig")


### PR DESCRIPTION
Hello,

I manage several clusters using [kubie](https://github.com/sbstp/kubie/) which sets the `$KUBECONFIG` environment variable, following [the Kubernetes way](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#the-kubeconfig-environment-variable).
Thus, I never have a `~/.kube/config` on my computer, which makes the command panic:

```
kubectl browse-pvc -n communications signal-cli-rest-api-config
panic: stat /home/bcourtel/.kube/config: no such file or directory

goroutine 1 [running]:
main.getClientSetFromKubeconfig()
        /home/runner/work/kubectl-browse-pvc/kubectl-browse-pvc/util.go:91 +0x145
main.getCommand(0xc00049c2c0)
        /home/runner/work/kubectl-browse-pvc/kubectl-browse-pvc/main.go:64 +0x94
github.com/urfave/cli/v2.(*Command).Run(0xc000422dc0, 0xc00049c2c0, {0xc0001ae000, 0x4, 0x4})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:274 +0x9eb
github.com/urfave/cli/v2.(*App).RunContext(0xc0001c0780, {0x192d390?, 0xc00019e010}, {0xc0001ae000, 0x4, 0x4})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:332 +0x616
github.com/urfave/cli/v2.(*App).Run(...)
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:309
main.main()
        /home/runner/work/kubectl-browse-pvc/kubectl-browse-pvc/main.go:51 +0x2dc
```

This PR reads the `$KUBECONFIG` environment variable and use it to locate the kubeconfig file if it is set.
Let me know if you're OK with this change!