### PR TITLE
Add Darwin x86_64 to the releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,13 @@ jobs:
     - name: ls
       run: ls -R
 
-    - name: Fix permissions linux
+    - name: Fix permissions linux AMD64
       run: chmod +x kubectl-browse-pvc-linux-x86_64/kubectl-browse-pvc
 
-    - name: Fix permissions darwin arm
+    - name: Fix permissions darwin ARM
       run: chmod +x kubectl-browse-pvc-darwin-arm/kubectl-browse-pvc
 
-    - name: Fix permissions darwin arm
+    - name: Fix permissions darwin AMD64
       run: chmod +x kubectl-browse-pvc-darwin-x86_64/kubectl-browse-pvc
 
     - name: Zip linux AMD64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
       with:
         artifacts: "kubectl-browse-pvc-darwin_arm.zip,kubectl-browse-pvc-darwin_amd64.zip,kubectl-browse-pvc-linux_amd64.zip"
         artifactErrorsFailBuild: true
+        skipIfReleaseExists: true
 
     - name: Check out Code
       uses: actions/checkout@v4.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,26 +21,34 @@ jobs:
       run: ls -R
 
     - name: Fix permissions linux
-      run: chmod +x kubectl-browse-pvc-linux/kubectl-browse-pvc
+      run: chmod +x kubectl-browse-pvc-linux-x86_64/kubectl-browse-pvc
 
-    - name: Fix permissions darwin
-      run: chmod +x kubectl-browse-pvc-darwin/kubectl-browse-pvc
+    - name: Fix permissions darwin arm
+      run: chmod +x kubectl-browse-pvc-darwin-arm/kubectl-browse-pvc
 
-    - name: Zip linux
+    - name: Fix permissions darwin arm
+      run: chmod +x kubectl-browse-pvc-darwin-x86_64/kubectl-browse-pvc
+
+    - name: Zip linux AMD64
       uses: montudor/action-zip@v1
       with:
-        args: zip -j kubectl-browse-pvc-linux.zip kubectl-browse-pvc-linux/kubectl-browse-pvc kubectl-browse-pvc-linux/LICENSE
+        args: zip -j kubectl-browse-pvc-linux_amd64.zip kubectl-browse-pvc-linux-x86_64/kubectl-browse-pvc kubectl-browse-pvc-linux-x86_64/LICENSE
 
-    - name: Zip darwin
+    - name: Zip darwin ARM
       uses: montudor/action-zip@v1
       with:
-        args: zip -j kubectl-browse-pvc-darwin.zip kubectl-browse-pvc-darwin/kubectl-browse-pvc kubectl-browse-pvc-darwin/LICENSE
+        args: zip -j kubectl-browse-pvc-darwin_arm.zip kubectl-browse-pvc-darwin-arm/kubectl-browse-pvc kubectl-browse-pvc-darwin-arm/LICENSE
+
+    - name: Zip darwin AMD64
+      uses: montudor/action-zip@v1
+      with:
+        args: zip -j kubectl-browse-pvc-darwin_amd64.zip kubectl-browse-pvc-darwin-x86_64/kubectl-browse-pvc kubectl-browse-pvc-darwin-x86_64/LICENSE
 
     - name: Create Release
       id: create_release
       uses: ncipollo/release-action@v1
       with:
-        artifacts: "kubectl-browse-pvc-darwin.zip,kubectl-browse-pvc-linux.zip"
+        artifacts: "kubectl-browse-pvc-darwin_arm.zip,kubectl-browse-pvc-darwin_amd64.zip,kubectl-browse-pvc-linux_amd64.zip"
         artifactErrorsFailBuild: true
 
     - name: Check out Code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,6 @@ jobs:
       with:
         artifacts: "kubectl-browse-pvc-darwin_arm.zip,kubectl-browse-pvc-darwin_amd64.zip,kubectl-browse-pvc-linux_amd64.zip"
         artifactErrorsFailBuild: true
-        skipIfReleaseExists: true
 
     - name: Check out Code
       uses: actions/checkout@v4.0.0


### PR DESCRIPTION
I made the naming schema consistent between the build and release workflows. I also added Darwin x86_64 objects to the release as well for users. 

I was not able to test the krew artifact uploading as it is tied to the maintainer account. Builds for Darwin and release succeeded as expected.