### PR TITLE
feat: Additional capabilities when running as root

### DIFF
--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -60,21 +60,27 @@ func BuildPvcbGetJob(options PodOptions) *batchv1.Job {
 	// Setup SecurityContext
 	var allowPrivilegeEscalation bool
 	var runAsNonRoot bool
+	var capabilities corev1.Capabilities
 	if options.User == 0 {
 		runAsNonRoot = false
 		allowPrivilegeEscalation = true
+		capabilities = corev1.Capabilities{
+			Add:  []corev1.Capability{"CHOWN", "FOWNER"},
+			Drop: []corev1.Capability{"ALL"},
+		}
 	} else {
 		runAsNonRoot = true
 		allowPrivilegeEscalation = false
+		capabilities = corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		}
 	}
 
 	securityContext := corev1.SecurityContext{
 		RunAsUser:                &options.User,
 		RunAsNonRoot:             &runAsNonRoot,
 		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-		},
+		Capabilities:             &capabilities,
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: "RuntimeDefault",
 		},


### PR DESCRIPTION
This PR makes it so that it becomes possible to use `chown` and `chmod` when running as root user.
This would be very useful when troubleshooting file permissions in a PVC (for example when the application will not start due to mismatched user ownership/permissions)