### PR TITLE
Fix panic when building tolerations for a unbound volume

### DIFF
--- a/cmd/browse-pvc/main.go
+++ b/cmd/browse-pvc/main.go
@@ -119,12 +119,18 @@ func browseCommand(kubeConfigFlags *genericclioptions.ConfigFlags, pvcName strin
 		node = attachedPod.Spec.NodeName
 	}
 
+	var tolerationsForNode []corev1.Toleration = nil
+
 	// retrieve taints of the selected node to smartly build in tolerations
-	nodeTaints, err := utils.GetNodeTaints(clientset, attachedPod.Spec.NodeName)
-	if err != nil {
-		fmt.Printf("Failed to get taints for node: %s. Continuing as if there weren't any", attachedPod.Spec.NodeName)
+	if attachedPod != nil {
+		nodeTaints, err := utils.GetNodeTaints(clientset, attachedPod.Spec.NodeName)
+		if err != nil {
+			log.Printf("Failed to get taints for node: %s. Continuing as if there weren't any", attachedPod.Spec.NodeName)
+		}
+		if nodeTaints != nil {
+			tolerationsForNode = utils.BuildTolerationsForTaints(nodeTaints)
+		}
 	}
-	tolerationsForNode := utils.BuildTolerationsForTaints(nodeTaints)
 
 	options := &utils.PodOptions{
 		Image:       image,

--- a/internal/utils/taints_and_tolerations_test.go
+++ b/internal/utils/taints_and_tolerations_test.go
@@ -37,10 +37,23 @@ func TestGetNodeTaints(t *testing.T) {
 				},
 			),
 		},
+		{
+			name:   "Node not found returns error",
+			err:    nil,
+			client: fake.NewClientset(),
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			if test.name == "Node not found returns error" {
+				_, err := GetNodeTaints(test.client, "nonexistent-node")
+				if err == nil {
+					t.Errorf("Expected an error for a nonexistent node, got nil")
+				}
+				return
+			}
+
 			expectedTaints := []v1.Taint{
 				{
 					Key:    "key1",


### PR DESCRIPTION
Fixes #40 

If the tool is used on an unbound volume the tool panics when trying to build the tolerations due to it not be able to handle a nil node.