### PR TITLE
add read-only flag for PVC mounting options

### DIFF
--- a/cmd/browse-pvc/main.go
+++ b/cmd/browse-pvc/main.go
@@ -30,6 +30,7 @@ import (
 var image string
 var Version string
 var containerUser int
+var readOnly bool
 
 var validCommands = []string{"image", "container-user"}
 
@@ -57,6 +58,7 @@ func main() {
 
 	rootCmd.Flags().StringVarP(&image, "image", "i", "alpine", "Image to mount job to")
 	rootCmd.Flags().IntVarP(&containerUser, "container-user", "u", 0, "User ID to run the container as")
+	rootCmd.Flags().BoolVarP(&readOnly, "read-only", "r", false, "Mount the PVC as read-only")
 	kubeConfigFlags.AddFlags(rootCmd.Flags())
 
 	if err := rootCmd.Execute(); err != nil {
@@ -141,6 +143,7 @@ func browseCommand(kubeConfigFlags *genericclioptions.ConfigFlags, pvcName strin
 		Node:        node,
 		User:        int64(containerUser),
 		Tolerations: tolerationsForNode,
+		ReadOnly:    readOnly,
 	}
 
 	// Build the Job

--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -15,6 +15,7 @@ type PodOptions struct {
 	Node        string
 	User        int64
 	Tolerations []corev1.Toleration
+	ReadOnly    bool
 }
 
 var script = `
@@ -124,6 +125,7 @@ func BuildPvcbGetJob(options PodOptions) *batchv1.Job {
 								{
 									Name:      "target-pvc",
 									MountPath: "/mnt",
+									ReadOnly:  options.ReadOnly,
 								},
 							},
 						},
@@ -135,6 +137,7 @@ func BuildPvcbGetJob(options PodOptions) *batchv1.Job {
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 									ClaimName: options.Pvc.Name,
+									ReadOnly:  options.ReadOnly,
 								},
 							},
 						},


### PR DESCRIPTION
## Summary

Adds a `--read-only` (`-r`) flag that mounts the target PVC in read-only mode, preventing accidental modifications to volume contents.

Closes #43

## Changes
- Added `ReadOnly` field to `PodOptions` struct
- Added `--read-only` / `-r` CLI flag (default `false`)
- Set `ReadOnly` on both `VolumeMount` and `PersistentVolumeClaimVolumeSource` when the flag is enabled

## Usage

```
kubectl browse-pvc -n <namespace> -r <pvc-name>
```

## Testing

Verified against a live cluster. The pod spec correctly sets `readOnly: true` on both the volume mount and the PVC volume source:

```yaml
volumeMounts:
- mountPath: /mnt
  name: target-pvc
  readOnly: true
volumes:
- name: target-pvc
  persistentVolumeClaim:
    claimName: <pvc-name>
    readOnly: true
```

Write attempts from within the container are rejected as expected:

```
browse-<pvc-name>:/mnt$ touch test
touch: test: Read-only file system
```

Without the `-r` flag, behavior is unchanged (read-write mount).